### PR TITLE
Do not set subsystem on non windows platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,11 @@ target_include_directories(papercode PUBLIC vendors/imgui)
 
 target_link_libraries( papercode ${OPENGL_LIBRARIES} )
 target_link_libraries( papercode glfw )
-
 target_link_libraries( papercode core)
 
+if (WIN32)
 target_link_options( papercode PUBLIC "-Wl,--subsystem,windows" )
+endif()
 
 
 


### PR DESCRIPTION
Now project compiles on linux. Does not really work, as we don't have dialogs... but it compiles and loads. You need to bin in `/bin` since directory for loading resources is borked. But its a good start.

![image](https://github.com/shahfarhadreza/papercode/assets/21070/9744f554-f33a-47a5-b855-ee1c3de875ce)
